### PR TITLE
Refine the network configuration

### DIFF
--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -1,29 +1,43 @@
-bootstrap:
-  image: calee0219/docker-geth-cluster
-  container_name: bootstrap
-  entrypoint: /usr/bin/geth
-  command: "--networkid 110010 --nodekeyhex 091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --bootnodes enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@localhost:30303 --rpc --rpcaddr 0.0.0.0"
-  expose:
-    - "30303"
-    - "8545"
+version: '3'
+services:
+  bootstrap:
+    image: calee0219/docker-geth-cluster
+    container_name: bootstrap
+    entrypoint: /usr/bin/geth
+    command: "--networkid 110010 --nodekeyhex 091bd6067cb4612df85d9c1ff85cc47f259ced4d4cd99816b14f35650f59c322 --rpc --rpcaddr 0.0.0.0"
+    expose:
+      - "30303"
+      - "8545"
+    networks:
+      privnet:
+        ipv4_address: 10.5.0.100
 
+  eth:
+    image: calee0219/docker-geth-cluster
+    links:
+      - bootstrap
+    entrypoint: /usr/bin/geth
+    command: "--networkid 110010 --bootnodes enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@10.5.0.100:30303 --rpc --rpcaddr 0.0.0.0"
+    expose:
+      - "30303"
+      - "8545"
+    networks:
+      - privnet
 
-eth:
-  image: calee0219/docker-geth-cluster
-  links:
-    - bootstrap
-  entrypoint: /usr/bin/geth
-  command: "--networkid 110010 --bootnodes enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@bootstrap:30303 --rpc --rpcaddr 0.0.0.0"
-  expose:
-    - "30303"
-    - "8545"
+  miner:
+    image: calee0219/docker-geth-cluster
+    links:
+      - bootstrap
+    command: bash -c "geth --password <(echo -n 110010) account new && geth --networkid 110010 --bootnodes enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@10.5.0.100:30303 --rpc --rpcaddr 0.0.0.0 --mine"
+    expose:
+      - "30303"
+      - "8545"
+    networks:
+      - privnet
 
-
-miner:
-  image: calee0219/docker-geth-cluster
-  links:
-    - bootstrap
-  command: bash -c "geth --password <(echo -n 110010) account new && geth --networkid 110010 --bootnodes enode://288b97262895b1c7ec61cf314c2e2004407d0a5dc77566877aad1f2a36659c8b698f4b56fd06c4a0c0bf007b4cfb3e7122d907da3b005fa90e724441902eb19e@bootstrap:30303 --rpc --rpcaddr 0.0.0.0 --mine"
-  expose:
-    - "30303"
-    - "8545"
+networks:
+  privnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.5.0.0/24


### PR DESCRIPTION
The original docker-compose file may not fit all docker-compose versions (for example, my computer) because of the network configuration ambiguity.
This version hard-codes the network configuration, and the bootstrap node has a static IP address. Nodes and miners will find it by this static IP address.